### PR TITLE
Fix Flowerpot removing flower on restart

### DIFF
--- a/src/de/Ste3et_C0st/Furniture/Objects/garden/TFlowerPot.java
+++ b/src/de/Ste3et_C0st/Furniture/Objects/garden/TFlowerPot.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -38,7 +39,7 @@ public class TFlowerPot extends Furniture implements Listener {
 	
 	private void setPotState(){
 		pot=getLocation().getBlock();
-		if(pot.getType()==null||!pot.getType().equals(Material.FLOWER_POT)){pot.setType(Material.FLOWER_POT);}
+		if(pot.getType()==null||!Tag.FLOWER_POTS.isTagged(pot.getType())){pot.setType(Material.FLOWER_POT);}
 		getObjID().addBlock(Arrays.asList(pot));
 	}
 


### PR DESCRIPTION
- 1.13 separated the flowerpots into separate blocks use the Tag class to check if the block is any flowerpot and not just the base empty flowerpot